### PR TITLE
feat: 派对所有者管理能力 + 修复头像问号

### DIFF
--- a/app/controller/PartyController.php
+++ b/app/controller/PartyController.php
@@ -366,7 +366,73 @@ class PartyController extends BaseController
             ->field('user.id, user.username')
             ->select();
 
-        return json(['ret' => 1, 'users' => $members]);
+        return json([
+            'ret' => 1,
+            'users' => $members,
+            'is_owner' => $party->owner_id === $userId,
+            'owner_id' => (int)$party->owner_id,
+            'is_archived' => $party->isArchived(),
+        ]);
+    }
+
+    /**
+     * 移除派对成员（仅所有者）
+     */
+    public function removeMember(Request $request, int $partyId, int $userId): Json
+    {
+        $currentUserId = $this->currentUserId();
+
+        $party = Party::find($partyId);
+        if (! $party) {
+            return json(['ret' => 0, 'msg' => '派对不存在'], 404);
+        }
+
+        if ($party->owner_id !== $currentUserId) {
+            return json(['ret' => 0, 'msg' => '只有派对所有者可以移除成员'], 403);
+        }
+
+        if ($party->isArchived()) {
+            return json(['ret' => 0, 'msg' => '已归档的派对无法移除成员']);
+        }
+
+        if ($userId === $currentUserId) {
+            return json(['ret' => 0, 'msg' => '不能移除自己，如需解散请删除派对']);
+        }
+
+        if ($userId === (int)$party->owner_id) {
+            return json(['ret' => 0, 'msg' => '不能移除派对所有者']);
+        }
+
+        $member = PartyMember::where('party_id', $partyId)
+            ->where('user_id', $userId)
+            ->find();
+        if (! $member) {
+            return json(['ret' => 0, 'msg' => '该用户不是该派对的成员'], 404);
+        }
+
+        $relatedItems = Db::table('item')
+            ->where('party_id', $partyId)
+            ->where(function ($query) use ($userId) {
+                $query->where('initiator', $userId)
+                    ->whereOr('userid', $userId);
+            })
+            ->count();
+        if ($relatedItems > 0) {
+            return json([
+                'ret' => 0,
+                'msg' => '该成员存在支付/代付记录，无法移除',
+            ]);
+        }
+
+        try {
+            PartyMember::where('party_id', $partyId)
+                ->where('user_id', $userId)
+                ->delete();
+
+            return json(['ret' => 1, 'msg' => '已移除成员']);
+        } catch (Exception $e) {
+            return json(['ret' => 0, 'msg' => '移除失败：' . $e->getMessage()]);
+        }
     }
 
     /**

--- a/app/controller/UserController.php
+++ b/app/controller/UserController.php
@@ -658,6 +658,39 @@ class UserController extends BaseController
         return json(['ret' => 1, 'msg' => '更新成功']);
     }
 
+    /**
+     * 删除单条账目（仅派对所有者，未归档）
+     */
+    public function deleteItem(Request $request, int $id): Json
+    {
+        $currentUserId = $this->currentUserId();
+
+        $item = (new Item())->where('id', $id)->findOrEmpty();
+        if ($item->isEmpty()) {
+            return json(['ret' => 0, 'msg' => '账目不存在'], 404);
+        }
+
+        $party = Party::find($item->party_id);
+        if (! $party) {
+            return json(['ret' => 0, 'msg' => '账目所属派对不存在'], 404);
+        }
+
+        if ((int)$party->owner_id !== $currentUserId) {
+            return json(['ret' => 0, 'msg' => '只有派对所有者可以删除账目'], 403);
+        }
+
+        if ($party->isArchived()) {
+            return json(['ret' => 0, 'msg' => '已归档的派对无法删除账目']);
+        }
+
+        try {
+            $item->delete();
+            return json(['ret' => 1, 'msg' => '账目已删除']);
+        } catch (Exception $e) {
+            return json(['ret' => 0, 'msg' => '删除失败：' . $e->getMessage()]);
+        }
+    }
+
     public function logout(Request $request): Json
     {
         app()->userService->logout();

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,9 +5,20 @@ let refreshPromise: Promise<boolean> | null = null;
 
 export type AuthUser = { id: number; username: string; is_admin: boolean };
 
+export const AUTH_USER_CHANGED_EVENT = 'auth:user-changed';
+
+function notifyAuthUserChanged(): void {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(AUTH_USER_CHANGED_EVENT));
+  }
+}
+
 export function applyAuthPayload(data: { access_token?: string; user?: AuthUser }): void {
   if (data.access_token) accessToken = data.access_token;
-  if (data.user) setMe(data.user);
+  if (data.user) {
+    setMe(data.user);
+    notifyAuthUserChanged();
+  }
 }
 
 export function setAccessToken(token: string | null): void {
@@ -25,7 +36,10 @@ async function doRefresh(): Promise<boolean> {
     const data = (await res.json()) as { ret?: number; access_token?: string; user?: AuthUser };
     if (data.ret === 1 && data.access_token) {
       accessToken = data.access_token;
-      if (data.user) setMe(data.user);
+      if (data.user) {
+        setMe(data.user);
+        notifyAuthUserChanged();
+      }
       return true;
     }
     return false;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,5 +1,5 @@
-import {createContext, useCallback, useContext, useMemo, useState} from 'react';
-import type {AuthUser} from '@/api/client';
+import {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react';
+import {AUTH_USER_CHANGED_EVENT, type AuthUser} from '@/api/client';
 import {getMe, setMe as persistMe} from '@/lib/storage';
 
 type Ctx = {
@@ -15,6 +15,17 @@ export function AuthProvider({children}: { children: React.ReactNode }) {
     persistMe(u);
     setUserState(u);
   }, []);
+
+  useEffect(() => {
+    const handler = () => {
+      setUserState(getMe());
+    };
+    window.addEventListener(AUTH_USER_CHANGED_EVENT, handler);
+    return () => {
+      window.removeEventListener(AUTH_USER_CHANGED_EVENT, handler);
+    };
+  }, []);
+
   const v = useMemo(() => ({user, setUser}), [user, setUser]);
   return <AuthContext.Provider value={v}>{children}</AuthContext.Provider>;
 }

--- a/frontend/src/pages/parties/PartyMembersPage.tsx
+++ b/frontend/src/pages/parties/PartyMembersPage.tsx
@@ -1,11 +1,20 @@
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {useParams} from 'react-router-dom';
-import {Avatar, Typography} from 'antd';
-import {TeamOutlined} from '@ant-design/icons';
-import {apiFetch} from '@/api/client';
+import {Avatar, Button, message, Modal, Tag, Typography} from 'antd';
+import {CrownOutlined, TeamOutlined, UserDeleteOutlined} from '@ant-design/icons';
+import {apiDelete, apiFetch} from '@/api/client';
 import {EmptyState, PageShell, SectionTitle, SurfaceCard} from '@/components/ui';
 
 type MemberRow = { id?: number; username?: string };
+
+type MembersResponse = {
+  ret: number;
+  msg?: string;
+  users?: MemberRow[];
+  is_owner?: boolean;
+  owner_id?: number;
+  is_archived?: boolean;
+};
 
 export function PartyMembersPage() {
   const {id} = useParams();
@@ -13,20 +22,73 @@ export function PartyMembersPage() {
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
   const [users, setUsers] = useState<MemberRow[]>([]);
+  const [isOwner, setIsOwner] = useState(false);
+  const [ownerId, setOwnerId] = useState<number | null>(null);
+  const [archived, setArchived] = useState(false);
+  const [removingId, setRemovingId] = useState<number | null>(null);
 
-  useEffect(() => {
-    void (async () => {
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
       const r = await apiFetch(`/user/party/${partyId}/users`);
-      const res = (await r.json()) as { ret: number; msg?: string; users?: MemberRow[] };
+      const res = (await r.json()) as MembersResponse;
       if (res.ret !== 1) {
         setErr(res.msg || '无法加载成员');
         setUsers([]);
-      } else {
-        setUsers(res.users || []);
+        return;
       }
+      setUsers(res.users || []);
+      setIsOwner(res.is_owner === true);
+      setOwnerId(res.owner_id ?? null);
+      setArchived(res.is_archived === true);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
       setLoading(false);
-    })();
+    }
   }, [partyId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const removeMember = (member: MemberRow) => {
+    if (!member.id) return;
+    const targetId = member.id;
+    const targetName = member.username || `ID ${targetId}`;
+    Modal.confirm({
+      title: '确认移除该成员？',
+      okType: 'danger',
+      okText: '确认移除',
+      cancelText: '取消',
+      content: (
+        <div>
+          <Typography.Paragraph style={{marginBottom: 8}}>
+            将把成员 <Typography.Text strong>{targetName}</Typography.Text> 从派对中移除，此操作不可撤销。
+          </Typography.Paragraph>
+          <Typography.Paragraph type="secondary" style={{marginBottom: 0}}>
+            若该成员存在任何已发起或被指定支付/代付的账目（不论是否已付），后端将拒绝移除。
+          </Typography.Paragraph>
+        </div>
+      ),
+      onOk: async () => {
+        setRemovingId(targetId);
+        try {
+          const r = await apiDelete(`/user/party/${partyId}/member/${targetId}`);
+          const out = (await r.json()) as { ret: number; msg?: string };
+          if (out.ret !== 1) {
+            message.error(out.msg || '移除失败');
+            return;
+          }
+          message.success(out.msg || '已移除成员');
+          await load();
+        } finally {
+          setRemovingId(null);
+        }
+      },
+    });
+  };
 
   return (
     <PageShell
@@ -42,21 +104,42 @@ export function PartyMembersPage() {
           <EmptyState description="暂无成员"/>
         ) : (
           <ul className="bbs-party-member-list">
-            {users.map((m) => (
-              <li key={m.id ?? m.username} className="bbs-party-member">
-                <Avatar size={40} style={{background: '#e0f2fe', color: '#0369a1', flexShrink: 0}}>
-                  {(m.username || '?').charAt(0).toUpperCase()}
-                </Avatar>
-                <div className="bbs-party-member__info">
-                  <Typography.Text strong>{m.username || '—'}</Typography.Text>
-                  {m.id != null ? (
-                    <Typography.Text type="secondary" style={{fontSize: 12, display: 'block'}}>
-                      ID {m.id}
-                    </Typography.Text>
+            {users.map((m) => {
+              const isMemberOwner = m.id != null && ownerId != null && m.id === ownerId;
+              const canRemove =
+                isOwner && !archived && !isMemberOwner && m.id != null;
+              return (
+                <li key={m.id ?? m.username} className="bbs-party-member">
+                  <Avatar size={40} style={{background: '#e0f2fe', color: '#0369a1', flexShrink: 0}}>
+                    {(m.username || '?').charAt(0).toUpperCase()}
+                  </Avatar>
+                  <div className="bbs-party-member__info" style={{flex: 1}}>
+                    <Typography.Text strong>{m.username || '—'}</Typography.Text>
+                    {isMemberOwner ? (
+                      <Tag icon={<CrownOutlined/>} color="gold" style={{marginInlineStart: 8}}>
+                        所有者
+                      </Tag>
+                    ) : null}
+                    {m.id != null ? (
+                      <Typography.Text type="secondary" style={{fontSize: 12, display: 'block'}}>
+                        ID {m.id}
+                      </Typography.Text>
+                    ) : null}
+                  </div>
+                  {canRemove ? (
+                    <Button
+                      danger
+                      size="small"
+                      icon={<UserDeleteOutlined/>}
+                      loading={removingId === m.id}
+                      onClick={() => removeMember(m)}
+                    >
+                      移除
+                    </Button>
                   ) : null}
-                </div>
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         )}
       </SurfaceCard>

--- a/frontend/src/pages/parties/PartyShowPage.tsx
+++ b/frontend/src/pages/parties/PartyShowPage.tsx
@@ -159,6 +159,42 @@ export function PartyShowPage() {
     });
   };
 
+  const deleteItem = (item: PartyItem) => {
+    Modal.confirm({
+      title: '确认删除该账目？',
+      okType: 'danger',
+      okText: '确认删除',
+      cancelText: '取消',
+      content: (
+        <div>
+          <Typography.Paragraph style={{marginBottom: 8}}>
+            将删除账目
+            {item.description ? (
+              <>
+                {' '}
+                <Typography.Text strong>{item.description}</Typography.Text>
+              </>
+            ) : null}
+            ，此操作不可恢复。
+          </Typography.Paragraph>
+          <Typography.Paragraph type="secondary" style={{marginBottom: 0}}>
+            支付人 {item.payer_name || '—'} · 发起人 {item.initiator_name || '—'}
+          </Typography.Paragraph>
+        </div>
+      ),
+      onOk: async () => {
+        const r = await apiDelete(`/user/item/${item.id}`);
+        const out = (await r.json()) as { ret: number; msg?: string };
+        if (out.ret !== 1) {
+          message.error(out.msg || '删除失败');
+          return;
+        }
+        message.success(out.msg || '账目已删除');
+        await load();
+      },
+    });
+  };
+
   const archive = () => {
     Modal.confirm({
       title: '归档派对',
@@ -349,6 +385,17 @@ export function PartyShowPage() {
                   meta: `支付人 ${it.payer_name || '—'} · 发起人 ${it.initiator_name || '—'}`,
                   amount: formatMoney(sym, parseAmount(it.amount)),
                   paid,
+                  action:
+                    isOwner && !archived ? (
+                      <Button
+                        danger
+                        size="small"
+                        icon={<DeleteOutlined/>}
+                        onClick={() => deleteItem(it)}
+                      >
+                        删除
+                      </Button>
+                    ) : undefined,
                 };
               })}
               empty={

--- a/route/app.php
+++ b/route/app.php
@@ -30,6 +30,7 @@ Route::group('api', function () {
         Route::post('item/add', 'user/processAddItem');
         Route::get('item/party/:partyId', 'user/itemListByParty');
         Route::post('item/:id', 'user/updateItemStatus');
+        Route::delete('item/:id', 'user/deleteItem');
         Route::get('item', 'user/itemList');
         Route::post('logout', 'user/logout');
         Route::get('profile', 'user/profile');
@@ -55,6 +56,7 @@ Route::group('api', function () {
         Route::get('party/:id/edit', 'party/edit');
         Route::post('party/:id/update', 'party/update');
         Route::post('party/:id/leave', 'party/leave');
+        Route::delete('party/:partyId/member/:userId', 'party/removeMember');
         Route::post('party/:id/archive', 'party/archive');
         Route::get('party/:partyId/archive/download', 'party/downloadArchiveExport');
         Route::post('party/validate-timezone', 'party/validateTimezone');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

本次包含 3 个独立改动，分别解决以下需求：

1. **派对所有者可移除成员**（含校验和确认弹窗）
2. **派对所有者可删除单条支付/代付账目**（含确认弹窗）
3. **修复 token 自动续签后右上角头像残留 `?` 的问题**

---

## 1. 派对所有者移除成员

### 后端
- `route/app.php`：新增 `DELETE /api/user/party/:partyId/member/:userId`
- `PartyController::removeMember`：依次校验
  1. JWT 中的 `currentUserId()`；
  2. 派对存在；
  3. `party.owner_id === currentUserId`（403）；
  4. 派对未归档；
  5. 不能移除自己（应走删除派对）；
  6. 不能移除 owner；
  7. 目标确为该派对成员；
  8. **目标在该派对内不存在任何 item（`initiator=$userId OR userid=$userId`，不论 `paid`），否则拒绝**，msg "该成员存在支付/代付记录，无法移除"。
- `PartyController::getMembers`：响应中追加 `is_owner` / `owner_id` / `is_archived` 供前端判断。

### 前端
- `PartyMembersPage.tsx`：在 owner 且未归档时为非 owner 成员显示"移除"按钮，点击触发 `Modal.confirm` danger 二次确认弹窗，明确告知存在账目时将被拒绝；失败时通过 `message.error` 展示后端 msg。

---

## 2. 派对所有者删除单条账目

### 后端
- `route/app.php`：新增 `DELETE /api/user/item/:id`
- `UserController::deleteItem`：校验 item 存在、所属 party 存在、`party.owner_id === currentUserId`、派对未归档；通过后 `item->delete()`。

### 前端
- `PartyShowPage.tsx`：账目列表对 owner 且未归档时每行显示 danger "删除"按钮，点击触发 `Modal.confirm` 二次确认弹窗（含描述、支付人/发起人信息），成功后刷新页面。

---

## 3. 修复 token 续签后头像问号

### 根因
新标签页打开时 `sessionStorage` 为空，`AuthProvider` 初始化 `user=null`；`PrivateRoute` 调用 `tryRefresh()` 成功后只更新了内存 `accessToken` 与 `sessionStorage`（见 `client.ts.doRefresh`），并未同步到 `AuthContext` 的 React state，导致 `MainLayout` 头像 `initial='?'`，需手动刷新页面才会从 `sessionStorage` 再次读取。

### 修复
- `client.ts`：新增 `AUTH_USER_CHANGED_EVENT`，在 `applyAuthPayload` 与 `doRefresh` 写入 `setMe(...)` 之后通过 `window.dispatchEvent` 派发全局事件；
- `AuthContext.tsx`：`AuthProvider` 内 `useEffect` 监听该事件，回调中 `setUserState(getMe())`，卸载时取消监听。

覆盖了"新标签首次刷新"、"会话内 401 自动续签"、"登录/MFA 成功"等所有 `setMe` 路径，无需手动刷新页面即可恢复正确的头像/用户名。

---

## 安全说明

- 所有删除接口的身份均来源于 `JwtAuth` 中间件注入的 `currentUserId()`，**路径参数仅作目标对象使用**；前端按钮显隐仅作 UX，不构成权限。
- 即便绕过前端直接请求 `DELETE /api/user/party/X/member/Y` 或 `DELETE /api/user/item/Z`：非 owner 用户、对 owner 自身或他人的越权调用、对已归档派对、对仍有账目的成员，均会被对应校验阶段拦截。
- 同步审计了现有所有写操作/敏感读操作接口（archive、destroy、update、edit、leave、clearPartyBestPay、updateItemStatus、processAddItem 等），均已正确使用 `currentUserId()` 进行 user_id 校验，无需补强。

---

## 测试建议

- [ ] 派对 owner：可移除无账目的普通成员；尝试移除存在 item（已付或未付）的成员时应被拒绝；尝试移除自己或 owner 时应被拒绝；归档派对应禁止移除。
- [ ] 派对 owner：可删除单条账目；归档派对应禁止删除。
- [ ] 非 owner 直接调用 `DELETE` 接口应被 403/拒绝。
- [ ] 新标签页打开应用：首次进入后头像应正确显示用户名首字母，无问号残留。
- [ ] 会话内 access token 过期、自动续签：UI 状态保持一致，无需手动刷新。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d2cdbcc-520f-4b16-aac3-dba4018ffd33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d2cdbcc-520f-4b16-aac3-dba4018ffd33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

