### PR TITLE
fix(frontend): 优化派对页邀请链接手机端布局

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -479,37 +479,84 @@ body {
     flex-shrink: 0;
 }
 
+.bbs-party-invite-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+    min-width: 0;
+}
+
 .bbs-party-invite {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     gap: 8px;
-    padding: 4px 12px;
+    padding: 8px 12px;
     border-radius: 8px;
     background: rgba(255, 255, 255, 0.85);
     border: 1px solid #e2e8f0;
     font-size: 13px;
     color: #64748b;
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+}
+
+.bbs-party-invite__label {
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+.bbs-party-invite .ant-typography-copy {
+    margin-inline-start: 4px;
 }
 
 .bbs-party-invite-link {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     gap: 8px;
-    padding: 4px 12px;
+    padding: 8px 8px 8px 12px;
     border-radius: 8px;
     background: rgba(13, 148, 136, 0.06);
     border: 1px solid rgba(13, 148, 136, 0.2);
     font-size: 13px;
     color: #64748b;
-    max-width: 100%;
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
 }
 
-.bbs-party-invite-link__text {
-    max-width: min(360px, 70vw);
+.bbs-party-invite-link__icon {
+    flex-shrink: 0;
+    color: #64748b;
+}
+
+.bbs-party-invite-link__label {
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+.bbs-party-invite-link__url {
+    flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: 12px !important;
+    font-size: 12px;
+    color: #0f766e;
+}
+
+.bbs-party-invite-link__copy-btn {
+    flex-shrink: 0;
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    min-width: 40px !important;
+    min-height: 40px !important;
+    width: 40px !important;
+    height: 40px !important;
+    padding: 0 !important;
+    margin: -4px -4px -4px 0;
     color: #0f766e !important;
 }
 
@@ -928,6 +975,24 @@ a.bbs-entity-card:hover {
 @media (max-width: 768px) {
     .bbs-party-hero .ant-card-body {
         padding: 18px 16px !important;
+    }
+
+    .bbs-party-invite,
+    .bbs-party-invite-link {
+        padding: 10px 12px;
+    }
+
+    .bbs-party-invite-link {
+        padding-right: 8px;
+    }
+
+    .bbs-party-invite .ant-typography-copy {
+        min-width: 36px;
+        min-height: 36px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-inline-start: auto;
     }
 
     .bbs-party-item {

--- a/frontend/src/pages/parties/PartyShowPage.tsx
+++ b/frontend/src/pages/parties/PartyShowPage.tsx
@@ -10,6 +10,7 @@ import {
   DownloadOutlined,
   EditOutlined,
   InboxOutlined,
+  CopyOutlined,
   LinkOutlined,
   LogoutOutlined,
   MoreOutlined,
@@ -112,6 +113,16 @@ export function PartyShowPage() {
   const isOwner = data?.isOwner === true;
   const members = data?.members || [];
   const items = data?.items || [];
+
+  const inviteUrl = party?.invite_code ? buildPartyInviteUrl(party.invite_code) : '';
+
+  const copyInviteLink = useCallback(() => {
+    if (!inviteUrl) return;
+    void navigator.clipboard.writeText(inviteUrl).then(
+      () => message.success('链接已复制'),
+      () => message.error('复制失败，请手动选择链接'),
+    );
+  }, [inviteUrl]);
 
   const stats = useMemo(() => {
     let total = 0;
@@ -285,24 +296,29 @@ export function PartyShowPage() {
               ) : null}
               <Flex gap={8} wrap="wrap" align="center" vertical style={{width: '100%'}}>
                 {party?.invite_code ? (
-                  <Flex gap={8} wrap="wrap" align="center">
-                    <span className="bbs-party-invite">
-                      邀请码
+                  <div className="bbs-party-invite-group">
+                    <div className="bbs-party-invite">
+                      <span className="bbs-party-invite__label">邀请码</span>
                       <Typography.Text code copyable={{text: party.invite_code}}>
                         {party.invite_code}
                       </Typography.Text>
-                    </span>
-                    <span className="bbs-party-invite-link">
-                      <LinkOutlined style={{color: '#64748b'}}/>
-                      邀请链接
-                      <Typography.Text
-                        copyable={{text: buildPartyInviteUrl(party.invite_code), tooltips: ['复制链接', '已复制']}}
-                        className="bbs-party-invite-link__text"
-                      >
-                        {buildPartyInviteUrl(party.invite_code)}
-                      </Typography.Text>
-                    </span>
-                  </Flex>
+                    </div>
+                    <div className="bbs-party-invite-link">
+                      <LinkOutlined className="bbs-party-invite-link__icon"/>
+                      <span className="bbs-party-invite-link__label">邀请链接</span>
+                      <span className="bbs-party-invite-link__url" title={inviteUrl}>
+                        {inviteUrl}
+                      </span>
+                      <Button
+                        type="text"
+                        size="small"
+                        className="bbs-party-invite-link__copy-btn"
+                        icon={<CopyOutlined/>}
+                        aria-label="复制邀请链接"
+                        onClick={copyInviteLink}
+                      />
+                    </div>
+                  </div>
                 ) : null}
                 <Typography.Text type="secondary" style={{fontSize: 12}}>
                   分享链接给好友，对方打开后可预览并加入


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

派对详情页（`PartyShowPage`）在手机端存在邀请链接区域布局异常：
- 邀请码与邀请链接横向并排，窄屏下内容被挤压
- 邀请链接 URL 的 `overflow: hidden` 应用在 Ant Design `copyable` 的同一容器上，导致复制图标被裁剪或无法点击

## 修改

### `PartyShowPage.tsx`
- 邀请码与邀请链接改为纵向全宽排列（`bbs-party-invite-group`）
- 邀请链接拆分为：图标 + 标签 + URL 文本 + 独立复制按钮
- 使用 `navigator.clipboard` + 40px 触控按钮替代内联 `Typography.Text copyable`

### `app.css`
- 邀请区域改为 `flex` 全宽布局，URL 文本单独省略号截断
- 复制按钮固定 40×40px 触控区域
- 移动端增大邀请码 `copyable` 图标的点击范围

## 验证

- [x] `npm run build` 通过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02bc5f13-e169-4e4e-aab3-b97adc165113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02bc5f13-e169-4e4e-aab3-b97adc165113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

